### PR TITLE
Updates to wazero beta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/F21/javy-wazero
 
 go 1.18
 
-require github.com/tetratelabs/wazero v0.0.0-20220630052417-63f6b2231142
+require github.com/tetratelabs/wazero v1.0.0-beta.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-github.com/tetratelabs/wazero v0.0.0-20220523092326-5ed31d3c495d h1:OVaIrGwhWWvBsztdGYShF5XQUrf+n3d4rsEahI4NahI=
-github.com/tetratelabs/wazero v0.0.0-20220523092326-5ed31d3c495d/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
-github.com/tetratelabs/wazero v0.0.0-20220601110143-92ba4929e531 h1:MEwr6kBuK+N6IcHoWCvqHFL2Kj47Wg9bjCr0EPwfq+k=
-github.com/tetratelabs/wazero v0.0.0-20220601110143-92ba4929e531/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
-github.com/tetratelabs/wazero v0.0.0-20220630052417-63f6b2231142 h1:ZnK50yYXmYRlAOpOzYw6Xu/QWU2kP8bDeVLQDzQtTas=
-github.com/tetratelabs/wazero v0.0.0-20220630052417-63f6b2231142/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v1.0.0-beta.1 h1:O5DZxiXG0WUUjuq4dwomA5gODRNnzF8LzQ+UOqGY5kY=
+github.com/tetratelabs/wazero v1.0.0-beta.1/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=

--- a/shopify-javy/example.go
+++ b/shopify-javy/example.go
@@ -21,7 +21,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a new WebAssembly Runtime.
-	r := wazero.NewRuntime()
+	r := wazero.NewRuntime(ctx)
 	defer r.Close(ctx) // This closes everything this Runtime created.
 
 	// Instantiate WASI, which implements system I/O such as console output.

--- a/shopify-javy/shopify_test.go
+++ b/shopify-javy/shopify_test.go
@@ -15,7 +15,7 @@ func BenchmarkShopifyInstantiateModule(b *testing.B) {
 	ctx := context.Background()
 
 	// Create a new WebAssembly Runtime.
-	r := wazero.NewRuntime()
+	r := wazero.NewRuntime(ctx)
 	defer r.Close(ctx) // This closes everything this Runtime created.
 
 	// Instantiate WASI, which implements system I/O such as console output.

--- a/suborbital-javy/example.go
+++ b/suborbital-javy/example.go
@@ -24,7 +24,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a new WebAssembly Runtime.
-	r := wazero.NewRuntime()
+	r := wazero.NewRuntime(ctx)
 	defer r.Close(ctx) // This closes everything this Runtime created.
 
 	// Instantiate WASI, which implements system I/O such as console output.

--- a/suborbital-javy/suborbital_test.go
+++ b/suborbital-javy/suborbital_test.go
@@ -16,7 +16,7 @@ func BenchmarkSuborbitalCallFunction(b *testing.B) {
 	ctx := context.Background()
 
 	// Create a new WebAssembly Runtime.
-	r := wazero.NewRuntime()
+	r := wazero.NewRuntime(ctx)
 	defer r.Close(ctx) // This closes everything this Runtime created.
 
 	// Instantiate WASI, which implements system I/O such as console output.


### PR DESCRIPTION
This updates to the first beta release of [wazero](https://wazero.io), 1.0.0-beta.1.

Future betas will release at the end of each month until 1.0 in February 2023.

Note: [Release notes](https://github.com/tetratelabs/wazero/releases) will be posted in the next day or two.

Meanwhile, we've also opened a [gophers slack](https://gophers.slack.com/) `#wazero` channel for support, updates and conversation! Note: You may need an [invite](https://invite.slack.golangbridge.org/) to join gophers.