### PR TITLE
deps: updates wazero to 1.0.0-pre.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/F21/javy-wazero
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-beta.2
+require github.com/tetratelabs/wazero v1.0.0-pre.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-beta.2 h1:Qa1R1oizAYHcmy8PljgINdXUZ/nRQkxUBbYfGSb4IBE=
-github.com/tetratelabs/wazero v1.0.0-beta.2/go.mod h1:CD5smBN5rGZo7UNe8aUiWyYE3bDWED/CQSonog9NSEg=
+github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
+github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=

--- a/shopify-javy/example.go
+++ b/shopify-javy/example.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	// Compile the module to reduce performance impact of instantiating it multiple times.
-	compiled, err := r.CompileModule(ctx, greetWasm, wazero.NewCompileConfig())
+	compiled, err := r.CompileModule(ctx, greetWasm)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/shopify-javy/shopify_test.go
+++ b/shopify-javy/shopify_test.go
@@ -24,7 +24,7 @@ func BenchmarkShopifyInstantiateModule(b *testing.B) {
 	}
 
 	// Compile the module to reduce performance impact of instantiating it multiple times.
-	compiled, err := r.CompileModule(ctx, greetWasm, wazero.NewCompileConfig())
+	compiled, err := r.CompileModule(ctx, greetWasm)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/suborbital-javy/example.go
+++ b/suborbital-javy/example.go
@@ -101,8 +101,9 @@ func callFunc(ctx context.Context, module api.Module, input string, results *syn
 
 // The Suborbital version of Javy expects these host functions to be implemented, but we only need "return_result"
 func registerHostFunctions(ctx context.Context, r wazero.Runtime, results *sync.Map) error {
-	_, err := r.NewModuleBuilder("env"). // They must be registered under "env"
-						ExportFunction("return_result", func(ctx context.Context, m api.Module, ptr uint32, len uint32, ident uint32) {
+	_, err := r.NewHostModuleBuilder("env"). // They must be registered under "env"
+							NewFunctionBuilder().
+							WithFunc(func(ctx context.Context, m api.Module, ptr uint32, len uint32, ident uint32) {
 			if ch, ok := results.Load(int32(ident)); ok {
 
 				resultCh, ok := ch.(chan []byte)
@@ -118,42 +119,68 @@ func registerHostFunctions(ctx context.Context, r wazero.Runtime, results *sync.
 				}
 			}
 		}).
-		ExportFunction("get_static_file", func(_ uint32, _ uint32, _ uint32) uint32 {
+		Export("return_result").
+		NewFunctionBuilder().
+		WithFunc(func(_ uint32, _ uint32, _ uint32) uint32 {
 			panic("get_static_file is unimplemented")
 		}).
-		ExportFunction("request_set_field", func(_ uint32, _ uint32, _ uint32, _ uint32, _ uint32, _ uint32) uint32 {
+		Export("get_static_file").
+		NewFunctionBuilder().
+		WithFunc(func(_ uint32, _ uint32, _ uint32, _ uint32, _ uint32, _ uint32) uint32 {
 			panic("request_set_field is unimplemented")
 		}).
-		ExportFunction("cache_get", func(_ uint32, _ uint32, _ uint32) uint32 {
+		Export("request_set_field").
+		NewFunctionBuilder().
+		WithFunc(func(_ uint32, _ uint32, _ uint32) uint32 {
 			panic("cache_get is unimplemented")
 		}).
-		ExportFunction("add_ffi_var", func(_ uint32, _ uint32, _ uint32, _ uint32, _ uint32) uint32 {
+		Export("cache_get").
+		NewFunctionBuilder().
+		WithFunc(func(_ uint32, _ uint32, _ uint32, _ uint32, _ uint32) uint32 {
 			panic("add_ffi_var is unimplemented")
 		}).
-		ExportFunction("get_ffi_result", func(_ uint32, _ uint32) uint32 {
+		Export("add_ffi_var").
+		NewFunctionBuilder().
+		WithFunc(func(_ uint32, _ uint32) uint32 {
 			panic("get_ffi_result is unimplemented")
 		}).
-		ExportFunction("return_error", func(_ uint32, _ uint32, _ uint32, _ uint32) {
+		Export("get_ffi_result").
+		NewFunctionBuilder().
+		WithFunc(func(_ uint32, _ uint32, _ uint32, _ uint32) {
 			panic("return_error is unimplemented")
 		}).
-		ExportFunction("fetch_url", func(_ uint32, _ uint32, _ uint32, _ uint32, _ uint32, _ uint32) uint32 {
+		Export("return_error").
+		NewFunctionBuilder().
+		WithFunc(func(_ uint32, _ uint32, _ uint32, _ uint32, _ uint32, _ uint32) uint32 {
 			panic("fetch_url is unimplemented")
 		}).
-		ExportFunction("graphql_query", func(_ uint32, _ uint32, _ uint32, _ uint32, _ uint32) uint32 {
+		Export("fetch_url").
+		NewFunctionBuilder().
+		WithFunc(func(_ uint32, _ uint32, _ uint32, _ uint32, _ uint32) uint32 {
 			panic("graphql_query is unimplemented")
 		}).
-		ExportFunction("db_exec", func(_ uint32, _ uint32, _ uint32, _ uint32) uint32 {
+		Export("graphql_query").
+		NewFunctionBuilder().
+		WithFunc(func(_ uint32, _ uint32, _ uint32, _ uint32) uint32 {
 			panic("db_exec is unimplemented")
 		}).
-		ExportFunction("cache_set", func(_ uint32, _ uint32, _ uint32, _ uint32, _ uint32, _ uint32) uint32 {
+		Export("db_exec").
+		NewFunctionBuilder().
+		WithFunc(func(_ uint32, _ uint32, _ uint32, _ uint32, _ uint32, _ uint32) uint32 {
 			panic("cache_set is unimplemented")
 		}).
-		ExportFunction("request_get_field", func(_ uint32, _ uint32, _ uint32, _ uint32) uint32 {
+		Export("cache_set").
+		NewFunctionBuilder().
+		WithFunc(func(_ uint32, _ uint32, _ uint32, _ uint32) uint32 {
 			panic("request_get_field is unimplemented")
 		}).
-		ExportFunction("log_msg", func(ctx context.Context, m api.Module, ptr uint32, size uint32, level uint32, ident uint32) {
+		Export("request_get_field").
+		NewFunctionBuilder().
+		WithFunc(func(ctx context.Context, m api.Module, ptr uint32, size uint32, level uint32, ident uint32) {
 			panic("log_msg is unimplemented")
-		}).Instantiate(ctx, r)
+		}).
+		Export("log_msg").
+		Instantiate(ctx, r)
 
 	return err
 }


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.3](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.3). Note: wazero 1.0 will require Go 1.18+

Notably, this improves performance and changes host function syntax.