### PR TITLE
deps: updates wazero to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,15 @@ To run the benchmarks, run `go test -bench=. ./...` from the root of the reposit
 Here are the results on my machine:
 ```
 goos: darwin
-goarch: amd64
+goarch: arm64
 pkg: github.com/F21/javy-wazero/shopify-javy
-cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
-BenchmarkShopifyInstantiateModule-16    	     597	   2099444 ns/op
+BenchmarkShopifyInstantiateModule-12    	    3548	    333316 ns/op
 PASS
-ok  	github.com/F21/javy-wazero/shopify-javy	4.342s
+ok  	github.com/F21/javy-wazero/shopify-javy	2.438s
 goos: darwin
-goarch: amd64
+goarch: arm64
 pkg: github.com/F21/javy-wazero/suborbital-javy
-cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
-BenchmarkSuborbitalCallFunction-16    	   13616	     85742 ns/op
+BenchmarkSuborbitalCallFunction-12    	   26733	     44817 ns/op
 PASS
-ok  	github.com/F21/javy-wazero/suborbital-javy	5.490s
+ok  	github.com/F21/javy-wazero/suborbital-javy	2.835s
 ```

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/F21/javy-wazero
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.4
+require github.com/tetratelabs/wazero v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/suborbital-javy/example.go
+++ b/suborbital-javy/example.go
@@ -40,7 +40,7 @@ func main() {
 	}
 
 	// Compile and instantiate the module
-	module, err := r.InstantiateModuleFromBinary(ctx, greetWasm)
+	module, err := r.Instantiate(ctx, greetWasm)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -73,7 +73,7 @@ func callFunc(ctx context.Context, module api.Module, input string, results *syn
 
 	defer module.ExportedFunction("deallocate").Call(ctx, inputPtr) // Remember to deallocate the memory after using it, otherwise it will leak!
 
-	if !module.Memory().Write(ctx, uint32(inputPtr), []byte(input)) { // Write the input to memory
+	if !module.Memory().Write(uint32(inputPtr), []byte(input)) { // Write the input to memory
 		return nil, err
 	}
 
@@ -112,7 +112,7 @@ func registerHostFunctions(ctx context.Context, r wazero.Runtime, results *sync.
 					log.Panicln("Channel is not the right type")
 				}
 
-				result, ok := m.Memory().Read(ctx, ptr, len) // Read the result written by the WebAssembly module
+				result, ok := m.Memory().Read(ptr, len) // Read the result written by the WebAssembly module
 
 				if ok {
 					resultCh <- result // Send it
@@ -180,7 +180,7 @@ func registerHostFunctions(ctx context.Context, r wazero.Runtime, results *sync.
 			panic("log_msg is unimplemented")
 		}).
 		Export("log_msg").
-		Instantiate(ctx, r)
+		Instantiate(ctx)
 
 	return err
 }

--- a/suborbital-javy/suborbital_test.go
+++ b/suborbital-javy/suborbital_test.go
@@ -32,7 +32,7 @@ func BenchmarkSuborbitalCallFunction(b *testing.B) {
 	}
 
 	// Compile and instantiate the module
-	module, err := r.InstantiateModuleFromBinary(ctx, greetWasm)
+	module, err := r.Instantiate(ctx, greetWasm)
 	if err != nil {
 		log.Panicln(err)
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0) which begins our compatibility promise.

On behalf of everyone in the community, I want to thank you for trying wazero before we became stable. We will not raise unsolicited pull requests anymore. That said, if any update gives you problems, please feel free to contact [us](https://wazero.io/community/) on slack or via a GitHub issue.